### PR TITLE
Fixing Issue 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ log.error('oh, snap!', err1, err2, [ 'thing', 123 ])
 Produces:
 ```
 23:00:46:035 ERROR oh, snap! (test/integration.js:16)
-  →  [Error: Error 1]
-  →  [Error: Error 2]
   →  { '0': 'thing', '1': 123 }
   →  Error: Error 1
   →      at Object.<anonymous> (/Users/Mark/projects/palin/test/integration.js:14:12)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "benchmark": "^1.0.0",
+    "bristol": "0.3.3",
     "chai": "^3.4.1",
     "eslint": "^1.10.3",
     "mocha": "^2.3.4"

--- a/palin.js
+++ b/palin.js
@@ -149,9 +149,11 @@ var formatter = function formatter(options, severity, date, elems) {
             }
         }
 
-        // add an error if it exists in the array
+        // add the element to the errors array if it's an error
         if (check.builtIn(element, Error)) {
             errors.push(element);
+            // the error will be concatinated later so continue to the next element
+            continue;
         }
 
         let objString = '\n' + util.inspect(element, { colors: true });

--- a/test/formatter.spec.js
+++ b/test/formatter.spec.js
@@ -86,7 +86,7 @@ describe('formatter', function() {
         };
 
         const result = palin({}, 'error', date, [message, new DerivedError(), aggObj]);
-        expect(chalk.stripColor(result)).to.contain('  11:11:11:111 ERROR error message (/Users/Mark/projects/palin/test/test.js:9)\n    →  [Error]\n    →  Error\n    →      at');
+        expect(chalk.stripColor(result)).to.contain('  11:11:11:111 ERROR error message (/Users/Mark/projects/palin/test/test.js:9)\n    →  Error\n    →      at');
     });
 
     describe('timestamp option', function() {


### PR DESCRIPTION
node.js changed the way errors are formatted when using node's util.inspect in node.js v6. Rather than back-porting this functionality or writing a compatibility layer, the best solution is to remove the logging of the error object representation (`[Error: Error 1]`) and simply log the stack-trace.

This will be a major release.
