### PR TITLE
Adding objectDepth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ log
   });
 ```
 
+#### Object Depth
+Palin formats objects using the built-in `require('util').inspect()`. Use the `objectDepth` option to increase depth of each object printed.
+
+```js
+log
+  .addTarget('console')
+  .withFormatter(palin, {
+    objectDepth: 5 // instead of inspect's default level ( usually 2 )
+  });
+```
+
 ## Other features
 Palin supports the concept of a "scope", which is a way of labeling groups of log messages. To use this, simply add an object with the key `scope` to the list of arguments. The color of the scope variable will be maintained for the lifetime of the the Bristol logger.
 

--- a/palin.js
+++ b/palin.js
@@ -86,8 +86,7 @@ var formatter = function formatter(options, severity, date, elems) {
     OPTIONS
     */
     const indent = options.indent || defaultIndent;
-    const objectDepth = check.undefined(options.objectDepth) ?
-        util.inspect.defaultOptions.depth : options.objectDepth;
+    const objectDepth = options.objectDepth;
     const timestamp = (function () {
         if (check.function(options.timestamp)) {
             return options.timestamp; // user-provided timestamp generating function

--- a/palin.js
+++ b/palin.js
@@ -86,6 +86,8 @@ var formatter = function formatter(options, severity, date, elems) {
     OPTIONS
     */
     const indent = options.indent || defaultIndent;
+    const objectDepth = check.undefined(options.objectDepth) ?
+        util.inspect.defaultOptions.depth : options.objectDepth;
     const timestamp = (function () {
         if (check.function(options.timestamp)) {
             return options.timestamp; // user-provided timestamp generating function
@@ -163,12 +165,12 @@ var formatter = function formatter(options, severity, date, elems) {
             continue;
         }
 
-        let objString = '\n' + util.inspect(element, { colors: true });
+        let objString = '\n' + util.inspect(element, { colors: true, depth: objectDepth });
         build += objString.replace(/\n/g, indent);
     }
 
     if (Object.keys(aggObj).length > 0) {
-        let objString = '\n' + util.inspect(aggObj, { colors: true });
+        let objString = '\n' + util.inspect(aggObj, { colors: true, depth: objectDepth });
         build += objString.replace(/\n/g, indent);
     }
 

--- a/test/formatter.spec.js
+++ b/test/formatter.spec.js
@@ -136,4 +136,23 @@ describe('formatter', function() {
             expect(chalk.stripColor(result)).to.equal('  11:11:11:111 LOG hello (test/test.js:9)');
         });
     });
+
+    describe('objectDepth option', function () {
+        it('should show objects of specified depth', function () {
+            const date = new Date(2000, 11, 11, 11, 11, 11, 111);
+            const message = 'hello';
+            const options = {
+                objectDepth: 4
+            };
+            const aggObj = {
+                file: '/Users/Mark/projects/palin/test/test.js',
+                line: '9',
+                test: {
+                    object: { is: { deep: { show: 'me' } } },
+                    another: { object: { is: { hidden: { because: { it: { is: { deeper: { hidden: true } } } } } } } } }
+            };
+            const result = palin(options, 'log', date, [message, aggObj]);
+            expect(chalk.stripColor(result)).to.equal('  11:11:11:111 LOG hello (/Users/Mark/projects/palin/test/test.js:9)\n    →  { test: \n    →     { object: { is: { deep: { show: \'me\' } } },\n    →       another: { object: { is: { hidden: [Object] } } } } }');
+        });
+    });
 });

--- a/test/formatter.spec.js
+++ b/test/formatter.spec.js
@@ -122,16 +122,18 @@ describe('formatter', function() {
     });
 
     describe('rootFolderName option', function () {
-        const date = new Date(2000, 11, 11, 11, 11, 11, 111);
-        const message = 'hello';
-        const options = {
-            rootFolderName: 'palin'
-        };
-        const aggObj = {
-            file: '/Users/Mark/projects/palin/test/test.js',
-            line: '9'
-        };
-        const result = palin(options, 'log', date, [message, aggObj]);
-        expect(chalk.stripColor(result)).to.equal('  11:11:11:111 LOG hello (test/test.js:9)');
+        it('should strip the root folder from the message', function () {
+            const date = new Date(2000, 11, 11, 11, 11, 11, 111);
+            const message = 'hello';
+            const options = {
+                rootFolderName: 'palin'
+            };
+            const aggObj = {
+                file: '/Users/Mark/projects/palin/test/test.js',
+                line: '9'
+            };
+            const result = palin(options, 'log', date, [message, aggObj]);
+            expect(chalk.stripColor(result)).to.equal('  11:11:11:111 LOG hello (test/test.js:9)');
+        });
     });
 });


### PR DESCRIPTION
Resolves #8 by adding an option of `objectDepth` that supports `null` for unlimited depth. 

Bonus: Fixed an existing test that wasn't actually running in an `it()` block.